### PR TITLE
DEV-14277 Update READMEs for repo name change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo follows the [terraform standard module structure](https://www.terrafor
 Inline example implementation of the module.  This is the most basic example of what it would look like to use this module.
 ```
 module "basic" {
-  source = "git::https://github.com/Datatamer/terraform-emr-tamr-vm?ref=0.2.2"
+  source = "git::https://github.com/Datatamer/terraform-aws-tamr-vm?ref=0.2.2"
   aws_role_name = "name-for-tamr-role"
   aws_instance_profile_name = "name-for-tamr-instance-profile"
   aws_account_id = "123456789012"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,5 +1,5 @@
 module "tamr-vm" {
-  source = "git::https://github.com/Datatamer/terraform-emr-tamr-vm"
+  source = "git::https://github.com/Datatamer/terraform-aws-tamr-vm"
   aws_role_name = "name-for-tamr-role"
   aws_instance_profile_name = "name-for-tamr-instance-profile"
   aws_account_id = "123456789012"

--- a/modules/aws-ec2-instance/README.md
+++ b/modules/aws-ec2-instance/README.md
@@ -8,7 +8,7 @@ This is the most basic example of what it would look like to use this module.
 
 ```
 module "aws-tamr-instance" {
-  source = "git::https://github.com/Datatamer/terraform-emr-tamr-vm/modules/aws-ec2-instance?ref=0.2.2"
+  source = "git::https://github.com/Datatamer/terraform-aws-tamr-vm/modules/aws-ec2-instance?ref=0.2.2"
   ami = "ami-123456789"
   iam_instance_profile = "iam-profile-id"
   key_name = "my-key"

--- a/modules/aws-iam-policies/README.md
+++ b/modules/aws-iam-policies/README.md
@@ -7,7 +7,7 @@ A minimal example implementation of the module is implemented in the examples fo
 This is the most basic example of what it would look like to use this module.
 ```
 module "aws-emr-creator-iam" {
-  source = "git::https://github.com/Datatamer/terraform-emr-tamr-vm/modules/aws-iam-policies?ref=0.2.2"
+  source = "git::https://github.com/Datatamer/terraform-aws-tamr-vm/modules/aws-iam-policies?ref=0.2.2"
   aws_role_name = "iam-role-name"
   aws_account_id = "12-digit-ARN"
 }

--- a/modules/aws-iam-role/README.md
+++ b/modules/aws-iam-role/README.md
@@ -8,7 +8,7 @@ This is the most basic example of what it would look like to use this module.
 
 ```
 module "aws-tamr-user-role" {
-  source = "git::https://github.com/Datatamer/terraform-emr-tamr-vm/modules/aws-iam-role?ref=0.2.2"
+  source = "git::https://github.com/Datatamer/terraform-aws-tamr-vm/modules/aws-iam-role?ref=0.2.2"
   aws_role_name = "iam-role-name"
 }
 ```

--- a/modules/aws-security-groups/README.md
+++ b/modules/aws-security-groups/README.md
@@ -8,7 +8,7 @@ This is the most basic example of what it would look like to use this module.
 
 ```
 module "aws-vm-sg" {
-  source = "git::https://github.com/Datatamer/terraform-emr-tamr-vm/modules/aws-security-groups?ref=0.2.2"
+  source = "git::https://github.com/Datatamer/terraform-aws-tamr-vm/modules/aws-security-groups?ref=0.2.2"
   vpc_id = "vpc-123456789"
   ingress_cidr_blocks = [
     "1.2.3.4/32",


### PR DESCRIPTION
Changed the repo name from `terraform-emr-tamr-vm` to `terraform-aws-tamr-vm` for [DEV-14277](https://datatamr.atlassian.net/browse/DEV-14277).