### PR TITLE
CA-9 - Add support for permissions boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Tamr VM Terraform Module
 
+## v3.1.0 - July 2nd 2021
+*  Adds new variable `permissions_boundary` to set the permissions boundary for the IAM Role used by the Tamr EC2 Instance
+
 ## v3.0.0 - July 1st 2021
 * Update to policy to remove wildcards wherever possible
 * New configuration variables:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Tamr VM Terraform Module
 
-## v3.1.0 - July 2nd 2021
+## v3.1.0 - July 6th 2021
 *  Adds new variable `permissions_boundary` to set the permissions boundary for the IAM Role used by the Tamr EC2 Instance
 
 ## v3.0.0 - July 1st 2021

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ No provider.
 | bootstrap\_scripts | List of body content of bootstrap shell scripts. | `list(string)` | `[]` | no |
 | enable\_volume\_encryption | Whether to encrypt the root block device | `bool` | `true` | no |
 | instance\_type | The instance type to use for the EC2 instance | `string` | `"c5.9xlarge"` | no |
+| permissions\_boundary | ARN of the policy that will be used to set the permissions boundary for the IAM Role | `string` | `null` | no |
 | security\_group\_ids | Security groups to associate with the ec2 instance | `list(string)` | `[]` | no |
 | tamr\_emr\_cluster\_ids | List of IDs for Static EMR clusters | `list(string)` | `[]` | no |
 | tamr\_emr\_role\_arns | List of ARNs for EMR Service and EMR EC2 roles | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ module "aws-iam-role" {
   source                    = "./modules/aws-iam-role"
   aws_role_name             = var.aws_role_name
   aws_instance_profile_name = var.aws_instance_profile_name
+  permissions_boundary      = var.permissions_boundary
 }
 
 module "aws-iam-policies" {

--- a/modules/aws-iam-role/README.md
+++ b/modules/aws-iam-role/README.md
@@ -35,6 +35,7 @@ This modules creates:
 |------|-------------|------|---------|:--------:|
 | aws\_instance\_profile\_name | IAM Instance Profile to create | `string` | `"tamr-instance-profile"` | no |
 | aws\_role\_name | IAM Role to create | `string` | `"tamr-instance-role"` | no |
+| permissions\_boundary | ARN of the policy that will be used to set the permissions boundary for the IAM Role | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/aws-iam-role/main.tf
+++ b/modules/aws-iam-role/main.tf
@@ -15,8 +15,9 @@ data "aws_iam_policy_document" "instance-assume-role-policy" {
 }
 
 resource "aws_iam_role" "tamr_user_iam_role" {
-  name               = var.aws_role_name
-  assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy.json
+  name                 = var.aws_role_name
+  assume_role_policy   = data.aws_iam_policy_document.instance-assume-role-policy.json
+  permissions_boundary = var.permissions_boundary
 }
 
 resource "aws_iam_instance_profile" "tamr_user_instance_profile" {

--- a/modules/aws-iam-role/variables.tf
+++ b/modules/aws-iam-role/variables.tf
@@ -9,3 +9,9 @@ variable "aws_instance_profile_name" {
   description = "IAM Instance Profile to create"
   default     = "tamr-instance-profile"
 }
+
+variable "permissions_boundary" {
+  type        = string
+  description = "ARN of the policy that will be used to set the permissions boundary for the IAM Role"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -111,3 +111,9 @@ variable "tamr_emr_role_arns" {
   default     = []
   description = "List of ARNs for EMR Service and EMR EC2 roles"
 }
+
+variable "permissions_boundary" {
+  type        = string
+  description = "ARN of the policy that will be used to set the permissions boundary for the IAM Role"
+  default     = null
+}


### PR DESCRIPTION
To allow for further tightening of IAM permissions, the TamrVM module should allow users to set a permissions boundary that will be attached to the IAM role associated to the EC2 Instance Profile.

Summary of changes:

- Module now exposes a string variable `permissions_boundary` 
- Expected value is the ARN of an existing policy (`null` by default)
- The variable is propagated to the aws-iam-role submodule
- If provided, the permissions boundary is attached to the created IAM Role

@souza-dan I tentatively updated the changelog. Feel free to make changes as you deem fit.